### PR TITLE
Add GitHub Action to validate helm-tester

### DIFF
--- a/.github/workflows/helm-tester.yaml
+++ b/.github/workflows/helm-tester.yaml
@@ -1,0 +1,16 @@
+name: Helm Tester
+on:
+  pull_request:
+  push:
+      branches:
+      - main
+permissions:
+  contents: read
+
+jobs:
+  helm-tester:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run verify container script
+        run: ./helm-tester.sh demo


### PR DESCRIPTION
This PR adds a simple GHA to run the helm-test.sh script using the demo chart in the repo.